### PR TITLE
add magic isset function to allow empty working on the magic getter

### DIFF
--- a/src/Twilio/Rest/Api/V2010/Account/MessageInstance.php
+++ b/src/Twilio/Rest/Api/V2010/Account/MessageInstance.php
@@ -167,6 +167,20 @@ class MessageInstance extends InstanceResource {
 
         throw new TwilioException('Unknown property: ' . $name);
     }
+    
+    /**
+     * Magic isset to access properties
+     *
+     * @param string $name Property to access
+     * @return boolean
+     */
+    public function __isset($name) {
+        if (array_key_exists($name, $this->properties)) {
+            return true;    
+        }
+        $getter = 'get' . ucfirst($name);
+        return method_exists($this, $getter);
+    }
 
     /**
      * Provide a friendly representation


### PR DESCRIPTION
According to 
https://stackoverflow.com/questions/6241039/php-empty-doesnt-work-with-a-getter-method
empty($twilioMessage->from) will return true even "from" is not empty